### PR TITLE
Fix minimal retry interval for trigger creation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ yc sls trigger create yds \
 	--invoke-function-id ${VOTE_FUNCTION_ID} \
 	--invoke-function-service-account-id ${MOVIES_API_SA_ID} \
 	--retry-attempts 3 \
-	--retry-interval 1s
+	--retry-interval 10s
 ```
 
 4. Для проставления оценки в спецификацию добавлена операция `postVote` со специальной интеграцией c DataStreams.


### PR DESCRIPTION
The minimal interval for retry is 10 seconds, according to the error message:

`ERROR: rpc error: code = InvalidArgument desc = Retry interval should belong to a range 10-60 seconds`